### PR TITLE
Removing not needed service in admin panel

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -113,12 +113,6 @@ chown -R root: $final_path
 ynh_use_logrotate
 
 #=================================================
-# ADVERTISE SERVICE IN ADMIN PANEL
-#=================================================
-
-yunohost service add NAME_INIT.D --log "/var/log/FILE.log"
-
-#=================================================
 # SETUP SSOWAT
 #=================================================
 


### PR DESCRIPTION
to fix package_linter error ✘ You used 'yunohost service add' in the install script, but not 'yunohost service remove' in the remove script. 